### PR TITLE
No nonstring aliases

### DIFF
--- a/Tests/QueryTest.php
+++ b/Tests/QueryTest.php
@@ -283,4 +283,40 @@ fragment imageFragment on image {
 ';
         $this->assertEquals($expected, (string) $operation);
     }
+
+    public function testQueryWithoutAliases()
+    {
+        $operation = new Operation(
+            Query::KEYWORD,
+            'test',
+            [],
+            [
+                'myAlias' => new Query(
+                    'myAliasedField',
+                    [],
+                    [
+                        'subfieldA'
+                    ]
+                ),
+                new Query(
+                    'unaliasedField',
+                    [],
+                    [
+                        'nosuchsubfield'
+                    ]
+                )
+            ]
+        );
+        $expected = 'query test {
+  myAlias: myAliasedField {
+    subfieldA
+  }
+  unaliasedField {
+    nosuchsubfield
+  }
+}
+';
+       $this->assertEquals($expected, (string) $operation);
+    }
+
 }

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -212,7 +212,11 @@ abstract class AbstractQuery implements QueryInterface
                 {
                     $field->type = $fieldAlias;
                 }
-                $fields[] = sprintf('%s: %s', $fieldAlias, $field->__toString());
+                if(is_string($fieldAlias)) {
+                    $fields[] = sprintf('%s: %s', $fieldAlias, $field->__toString());
+                } else {
+                    $fields[] = sprintf('%s', $field->__toString());
+                }
             }
         }
 

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -202,7 +202,11 @@ class Operation implements OperationInterface
                 {
                     $field->type = $fieldAlias;
                 }
-                $fields[] = sprintf('%s: %s', $fieldAlias, $field->__toString());
+                if(is_string($fieldAlias)) {
+                    $fields[] = sprintf('%s: %s', $fieldAlias, $field->__toString());
+                } else {
+                    $fields[] = sprintf('%s', $field->__toString());
+                }
             }
         }
 


### PR DESCRIPTION
This change allows you to query a nested object type without providing an alias (like a regular field)
i.e.
```
$op = new Operation(
    Query::KEYWORD,
    'getWallets',
    [],
    [
        'exampleA' => new Query(
            'exampleA',
            [],
            [
                'exampleB' => new Query(
                    'exampleB',
                    [],
                    [
                        'exampleC',
                        'exampleD',
                    ]
                ),
                'exampleE'
            ]
        )
    ]
);
```

could be provisioned as ->

```
$op = new Operation(
    Query::KEYWORD,
    'getWallets',
    [],
    [
        new Query(
            'exampleA',
            [],
            [
                new Query(
                    'exampleB',
                    [],
                    [
                        'exampleC',
                        'exampleD',
                    ]
                ),
                'exampleE'
            ]
        )
    ]
);
```
